### PR TITLE
chg: desabilitada dependência do libsodium #S-12793049

### DIFF
--- a/builds/msvc/vs2013/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2013/libzmq/libzmq.vcxproj
@@ -66,6 +66,54 @@
     <Import Project="$(ProjectDir)..\..\properties\Output.props" />
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLTCG|Win32'">
+    <Linkage-libsodium />
+    <Option-sodium />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugLTCG|Win32'">
+    <Linkage-libsodium />
+    <Option-sodium />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">
+    <Linkage-libsodium />
+    <Option-sodium />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLIB|Win32'">
+    <Linkage-libsodium />
+    <Option-sodium />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugLIB|Win32'">
+    <Linkage-libsodium />
+    <Option-sodium />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">
+    <Linkage-libsodium />
+    <Option-sodium />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLTCG|x64'">
+    <Linkage-libsodium />
+    <Option-sodium />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugLTCG|x64'">
+    <Linkage-libsodium />
+    <Option-sodium />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">
+    <Linkage-libsodium />
+    <Option-sodium />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLIB|x64'">
+    <Linkage-libsodium />
+    <Option-sodium />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugLIB|x64'">
+    <Linkage-libsodium />
+    <Option-sodium />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">
+    <Linkage-libsodium />
+    <Option-sodium />
+  </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\zmq.h" />
     <ClInclude Include="..\..\..\..\include\zmq_utils.h" />


### PR DESCRIPTION
- O Engine não necessita dessa camada de segurança.
- O branch utilizado pelo Engine é baseado na tag 4.1.2. A versão 4.1.4 requer o Vista, o que seria uma quebra de compatibilidade da versão atual do Engine. Após comunicação dos clientes, será atualizada para a última versão do zeromq.
